### PR TITLE
feat: add near-agent-market-autopilot skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ AI agent skills for NEAR Protocol blockchain development.
 | Skill                                                | Library                                                            | Description                                                                                                            |
 | ---------------------------------------------------- | ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
 | [near-ai-cloud](skills/near-ai-cloud/) | [NEAR AI Cloud Docs](https://docs.near.ai/cloud/introduction) | Verifiable private AI inference, TEE attestation, NRAS verification, GPU-CPU binding |
+| [near-agent-market-autopilot](skills/near-agent-market-autopilot/) | [Agent Market Skill Spec](https://market.near.ai/skill.md) | Autonomous market operator playbook with conservative bidding policy, replay-safe submissions, and settlement reconciliation |
 | [near-api-js](skills/near-api-js/)                   | [near-api-js](https://github.com/near/near-api-js)                 | JS/TS library for blockchain interaction, transactions, tokens, wallet integration                                     |
 | [near-dapp](skills/near-dapp/)                       | -                                                                  | Full-stack frontend development guide. Project setup, wallet integration, React/Next.js patterns, contract interaction |
 | [near-intents](skills/near-intents/)                 | [1Click API](https://docs.near-intents.org/)                       | Cross-chain swaps via REST API across EVM, Solana, NEAR, TON, Stellar, Tron                                            |
@@ -31,7 +32,7 @@ npx skills add near/agent-skills --skill <skill-name>
 bunx skills add near/agent-skills --skill <skill-name>
 ```
 
-Replace `<skill-name>` with: `near-ai-cloud`, `near-api-js`, `near-dapp`, `near-intents`, `near-kit`, or `near-smart-contracts`.
+Replace `<skill-name>` with: `near-agent-market-autopilot`, `near-ai-cloud`, `near-api-js`, `near-dapp`, `near-intents`, `near-kit`, or `near-smart-contracts`.
 
 ## Usage
 

--- a/skills/near-agent-market-autopilot/SKILL.md
+++ b/skills/near-agent-market-autopilot/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: near-agent-market-autopilot
+description: Autonomous NEAR Agent Market operations with deterministic bidding, guarded execution, stale bid withdrawal, settlement reconciliation, and replayable simulation. Use when operating or building bots that bid, submit deliverables, and reconcile earnings through market.near.ai.
+---
+
+# NEAR Agent Market Autopilot
+
+Production skill for operating an autonomous market worker with conservative defaults.
+
+## When to use
+
+Use this skill when you need to:
+
+- continuously scan and bid on NEAR Agent Market jobs,
+- enforce risk and profitability policy before posting bids,
+- auto-submit deliverables with deterministic manifest hashes,
+- reconcile completed jobs into auditable earnings reports,
+- replay historical snapshots to verify deterministic behavior.
+
+## Decision flow
+
+1. **Need one-shot execution?**
+Run `autopilot tick --config <config.json>`.
+
+2. **Need continuous operations?**
+Run `autopilot run --config <config.json>`.
+
+3. **Need only earnings reconciliation?**
+Run `autopilot reconcile --config <config.json>`.
+
+4. **Need dry-run / reproducibility check?**
+Run `autopilot simulate --input <snapshot.json> --policy <policy.json>`.
+
+5. **Need deployment sanity checks?**
+Run `autopilot doctor --config <config.json>`.
+
+## Core guarantees
+
+- conservative policy defaults (fail-closed, retry bounds, stale-withdraw windows),
+- deterministic bid and submission decisioning,
+- deterministic deliverable manifest hashing and optional HMAC signing,
+- stateful idempotency markers across restarts,
+- structured telemetry and metrics export.
+
+## References
+
+- [Architecture](references/architecture.md)
+- [Configuration](references/configuration.md)
+- [Incident Playbook](references/incident-playbook.md)
+- [Deployment](references/deployment.md)
+
+## Rules
+
+- [Safe Defaults](rules/safe-defaults.md)
+- [Bidding Strategy](rules/bidding-strategy.md)
+- [Retries and Escalation](rules/retries-escalation.md)
+- [Settlement Reconciliation](rules/settlement-reconciliation.md)
+- [Simulation and Replay](rules/simulation-replay.md)

--- a/skills/near-agent-market-autopilot/references/architecture.md
+++ b/skills/near-agent-market-autopilot/references/architecture.md
@@ -1,0 +1,24 @@
+# Architecture
+
+The autopilot SDK is organized as composable modules:
+
+1. `client/` — typed HTTP API wrappers for `market.near.ai`.
+2. `policy/` — conservative guardrails and mergeable policy overrides.
+3. `engine/bidding` — job ranking, bid sizing, undercut bounds, competition routing.
+4. `engine/lifecycle` — stale pending withdrawal, submission retries, escalation windows.
+5. `engine/settlement` — completed-job sweep and payout normalization.
+6. `state/` — durable key-value markers with `file` and `sqlite` adapters.
+7. `manifest/` — deterministic manifest hashing and optional signing.
+8. `simulation/` — deterministic replay output for reproducibility checks.
+9. `telemetry/` — event stream + Prometheus text exposition.
+10. `cli/` — operator command surface.
+
+Execution shape:
+
+1. Load policy and persisted state.
+2. Pull open jobs and current bids.
+3. Score/decide on bids (`bid` or `entry`) with hard limits.
+4. Sync tracked bids and withdraw stale pending bids.
+5. Attempt deliverable submissions using retry/backoff state.
+6. Reconcile completed jobs into settlement report.
+7. Emit structured telemetry for all state transitions.

--- a/skills/near-agent-market-autopilot/references/configuration.md
+++ b/skills/near-agent-market-autopilot/references/configuration.md
@@ -1,0 +1,45 @@
+# Configuration
+
+Example `config.json`:
+
+```json
+{
+  "agentId": "your-agent-id",
+  "market": {
+    "baseUrl": "https://market.near.ai",
+    "apiKey": "sk_live_...",
+    "timeoutMs": 10000,
+    "retry": { "attempts": 3, "backoffMs": 400 }
+  },
+  "state": {
+    "driver": "file",
+    "path": "./state/autopilot.json"
+  },
+  "nearPriceUsd": 4,
+  "submitSigningKey": "local-signing-key",
+  "submitSignerId": "autopilot",
+  "policy": {
+    "minBudgetNear": 0.05,
+    "maxBudgetNear": 20,
+    "bidDiscountBps": 7000,
+    "minBidNear": 0.03,
+    "maxBidNear": 10,
+    "maxExistingBids": 12,
+    "minMarginNear": 0.01,
+    "stalePendingBidMinutes": 30,
+    "submitRetryLimit": 4,
+    "submitRetryBackoffMinutes": 10,
+    "submitRetryMaxBackoffMinutes": 180,
+    "submitEscalateAfterMinutes": 45,
+    "submitEscalationLimit": 4,
+    "failClosed": true
+  }
+}
+```
+
+Notes:
+
+- `state.driver=file` is the default portable mode.
+- `state.driver=sqlite` requires a runtime that exposes `node:sqlite`.
+- `artifactProvider` is set in code and is required for real submissions.
+- `submitSigningKey` enables deterministic manifest signatures.

--- a/skills/near-agent-market-autopilot/references/deployment.md
+++ b/skills/near-agent-market-autopilot/references/deployment.md
@@ -1,0 +1,30 @@
+# Deployment
+
+## Local
+
+```bash
+pnpm install
+pnpm build
+autopilot doctor --config ./config.json
+autopilot tick --config ./config.json
+```
+
+## Continuous runner
+
+```bash
+autopilot run --config ./config.json --interval-ms 120000
+```
+
+## Containerized
+
+Use a standard long-running service profile:
+- run `autopilot doctor` as a readiness gate,
+- persist local state across restarts,
+- pass runtime config via environment variables or mounted config file.
+
+## Operational checklist
+
+1. API key stored in secret manager.
+2. State volume persisted across restarts.
+3. Alerting on `tick_error` and sustained `submit_failure`.
+4. Scheduled `reconcile` snapshot exported to accounting pipeline.

--- a/skills/near-agent-market-autopilot/references/incident-playbook.md
+++ b/skills/near-agent-market-autopilot/references/incident-playbook.md
@@ -1,0 +1,50 @@
+# Incident Playbook
+
+## 1) Repeated submit failures
+
+Symptoms:
+
+- `submit_failure` telemetry spikes
+- submission decisions returning `backoff_pending` or retry-limit reasons
+
+Actions:
+
+1. run `autopilot doctor --config <config.json>`
+2. inspect assignment state in `/v1/jobs/{job_id}`
+3. verify artifact generator output and manifest hash inputs
+4. if needed, request changes / reopen assignment path manually
+
+## 2) Bid spam or excessive pending bids
+
+Symptoms:
+
+- too many `pending` bids
+- elevated `bid_withdrawn` volume
+
+Actions:
+
+1. tighten `maxExistingBids`
+2. raise `minMarginNear`
+3. reduce `bidDiscountBps`
+4. decrease `stalePendingBidMinutes` for faster cleanup
+
+## 3) Earnings mismatch
+
+Symptoms:
+
+- settlement totals differ from expected dashboard numbers
+
+Actions:
+
+1. run `autopilot reconcile --config <config.json>`
+2. compare completed jobs + awarded bid IDs
+3. check fallback behavior where awarded bid amount is missing
+4. verify NEAR price input (`nearPriceUsd`) used for USD normalization
+
+## 4) Emergency stop
+
+Set conservative controls in config:
+
+- `policy.failClosed=true`
+- disable artifact provider integration in runtime wrapper
+- run only `reconcile` and `doctor` until API health is restored

--- a/skills/near-agent-market-autopilot/rules/bidding-strategy.md
+++ b/skills/near-agent-market-autopilot/rules/bidding-strategy.md
@@ -1,0 +1,9 @@
+# Bidding Strategy
+
+1. Skip jobs without NEAR-denominated budgets.
+2. Skip jobs outside policy budget limits.
+3. Skip highly saturated listings when existing bids exceed cap.
+4. Compute base bid from `budget * bidDiscountBps`.
+5. If live bids exist, undercut the lowest by a minimal step (`0.0001`).
+6. Clamp bid to policy min/max and budget ceiling.
+7. Route `job_type=competition` to `entry` action path.

--- a/skills/near-agent-market-autopilot/rules/retries-escalation.md
+++ b/skills/near-agent-market-autopilot/rules/retries-escalation.md
@@ -1,0 +1,8 @@
+# Retries and Escalation
+
+1. Submission retries are stateful per `(jobId,bidId)`.
+2. Respect `nextAttemptAt`; do not retry early.
+3. Increment attempts before each submit call.
+4. On failure, set exponential backoff bounded by max backoff.
+5. Escalate when wall-clock since `firstSeenAt` exceeds escalation window.
+6. Stop at retry limit and expose explicit skip reason.

--- a/skills/near-agent-market-autopilot/rules/safe-defaults.md
+++ b/skills/near-agent-market-autopilot/rules/safe-defaults.md
@@ -1,0 +1,7 @@
+# Safe Defaults
+
+1. Keep `failClosed=true`.
+2. Use bounded retries with exponential backoff.
+3. Enforce stale pending bid withdrawal windows.
+4. Enforce strict budget and margin filters before bidding.
+5. Persist state markers to durable storage, never in-memory only.

--- a/skills/near-agent-market-autopilot/rules/settlement-reconciliation.md
+++ b/skills/near-agent-market-autopilot/rules/settlement-reconciliation.md
@@ -1,0 +1,8 @@
+# Settlement Reconciliation
+
+1. Reconcile only `completed` jobs for the configured worker agent.
+2. Resolve payout from awarded bid amount when available.
+3. Fallback to own accepted bid amount if awarded amount is unavailable.
+4. Fallback to `budget_amount` only when token is `NEAR`.
+5. Normalize to USD using explicit `nearPriceUsd` input.
+6. Persist latest settlement cursor for incremental accounting workflows.

--- a/skills/near-agent-market-autopilot/rules/simulation-replay.md
+++ b/skills/near-agent-market-autopilot/rules/simulation-replay.md
@@ -1,0 +1,6 @@
+# Simulation and Replay
+
+1. Snapshot input must include jobs, bids-by-job, tracked bids, and policy overrides.
+2. Run `autopilot simulate` before policy changes.
+3. Compare `deterministicDigest` across runs to detect non-deterministic behavior.
+4. Use replay output to validate that safety guardrails trigger as expected.


### PR DESCRIPTION
## Summary

This PR adds a single new skill:
- `skills/near-agent-market-autopilot`

No SDK code, no workspace/tooling changes, no CI changes.

## What this skill is for

A playbook for operators building autonomous workers on `market.near.ai`, with emphasis on:
- conservative bidding defaults,
- replay-safe/idempotent submission behavior,
- settlement reconciliation,
- incident response and deterministic replay practices.

## Why this is useful in `agent-skills`

The repo already includes skills that capture operational guidance for NEAR systems. This addition contributes a focused market-operations skill with:
- `SKILL.md` decision flow,
- references (architecture/config/deployment/incident handling),
- rules (safe defaults, bidding, retries/escalation, settlement, replay).

## Scope

- Added: `skills/near-agent-market-autopilot/**`
- Updated: `README.md` skill table and install list
- Not included: SDK/CLI/runtime implementation

## Notes

This PR intentionally replaces the previously over-scoped approach with a small, skills-only contribution.
